### PR TITLE
fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,11 @@
-add_parent_path
 jpholiday
 kanilog
-loglevel
 mojimoji
 numpy
 pandas
 pdftotext
-pytest
-stdlogging
 tabula
 tabula_py
 urlpath
+kanirequests
+nth_weekday

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,9 @@ setup(
     packages=find_packages(exclude=("tests",)),
     package_data={'n225': ['data/n225.csv', 'data/initial_n225.csv']},
     install_requires=get_requires(),
+    extras_require={
+        "test":  ["add_parent_path", "loglevel", "pytest", "stdlogging", "PyYAML"],
+    },
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
The following packages are required.

- kanirequests
- nth_weekday

The following packages are used only for testing.

- add_parent_path
- loglevel
- pytest
- stdlogging